### PR TITLE
Split components from Home page - handle loading states

### DIFF
--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -1,0 +1,32 @@
+# Future improvements
+
+- Test coverage
+- Debounce search
+- React query for data fetching / caching
+- Paginate the search results / table
+- Sort functionality on the table headings
+- Hook up Database
+
+## Test coverage
+
+I opted to skip adding tests for the codebase and focus on solving the errors in the code / refactoring the UI components. Ideally, I'd create a test suite for each component and any associated logic. I wound up not spending any time in the backend of this codebase, but ideally would also be getting tests set up for the server as well.
+
+## Debounce search
+
+If there are potentially thousands of advocates in the database, filtering a giant list on every keystroke for search might be a performance concern. It would be great to implement debounce for the search functionality to cut down on that overhead.
+
+## ReactQuery / TanStackQuery
+
+I work with ReactQuery a fair amount in my current position and really enjoy how it handles data fetching and caching. It also offers functionality for infinite scroll which would be helpful when there's a big list of search results. Alternatively, you can use paginated queries which takes us to my next thought.
+
+## Paginate the search results / table
+
+If there are potentially thousands of advocates returned by the search, it might make sense to paginate the results. The user could tab through pages to see the next set of advocates that match the search.
+
+## Sort on table headings
+
+If I were a user, being able to sort based on the table headings would be a great extra piece of functionality. Especially for the city and years of experience columns, I could see that being something lots of users care about.
+
+## Hook up database
+
+I didn't have time to look at the database set up at all, but would have liked to work on that with more time.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Search from "./search";
+import TableHeader from "./tableHeader";
+import TableBody from './tableBody';
 
-type Advocate = {
+export type Advocate = {
   id: number,
   firstName: string,
   lastName: string,
@@ -14,89 +17,40 @@ type Advocate = {
   createdAt: string,
 }
 
-export default function Home() {
-  const [advocates, setAdvocates] = useState<Array<Advocate>>([]);
-  const [filteredAdvocates, setFilteredAdvocates] = useState<Array<Advocate>>([]);
+type AdvocatesDataState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'error', error: Error }
+  | { status: 'success', advocates: Array<Advocate> }
 
-  // TODO: handle loading / error states
+export default function Home() {
+  const [advocatesData, setAdvocatesData] = useState<AdvocatesDataState>({ status: 'idle' })
+  const [searchTerm, setSearchTerm] = useState<string>('');
+
   useEffect(() => {
+    setAdvocatesData({ status: 'loading'})
     console.log("fetching advocates...");
     fetch("/api/advocates").then((response) => {
       response.json().then((jsonResponse) => {
-        setAdvocates(jsonResponse.data);
-        setFilteredAdvocates(jsonResponse.data);
-      });
+        setAdvocatesData({ status: 'success', advocates: jsonResponse.data})
+      }).catch(error => {
+        setAdvocatesData({ status: 'error', error})
+      })
     });
   }, []);
 
-  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const searchTerm = e.target.value.toLowerCase();
-    const advocatesFiltered = advocates.filter((advocate: Advocate) => {
-      const specialtiesWithTerm = advocate.specialties.some((specialty) => specialty.toLowerCase().includes(searchTerm));
-      return (
-        advocate.firstName.toLowerCase().includes(searchTerm) ||
-        advocate.lastName.toLowerCase().includes(searchTerm) ||
-        advocate.city.toLowerCase().includes(searchTerm) ||
-        advocate.degree.toLowerCase().includes(searchTerm) ||
-        advocate.specialties.includes(searchTerm) ||
-        specialtiesWithTerm
-      );
-    });
-
-    setFilteredAdvocates(advocatesFiltered);
-  };
-
-  const onClick = () => {
-    setFilteredAdvocates(advocates);
-  };
-
   return (
     <main className="m-[24px]">
-      <h1 className="text-lg">Solace Advocates</h1>
-      <br />
-      <br />
-      <div>
-        <label htmlFor="search" className="p-2">Search</label>
-        <input className="border-2 border-solid mr-2" onChange={onChange} id="search" name="search" type="text" />
-        <button className="border-2 border-solid p-1" type="button" onClick={onClick}>Reset Search</button>
-      </div>
-      <br />
-      <br />
-      <table>
-        <thead>
-          <tr className="bg-black text-white border-2 border-solid text-left">
-            <th className="border-2 border-solid p-3">First Name</th>
-            <th className="border-2 border-solid p-3">Last Name</th>
-            <th className="border-2 border-solid p-3">City</th>
-            <th className="border-2 border-solid p-3">Degree</th>
-            <th className="border-2 border-solid p-3">Specialties</th>
-            <th className="border-2 border-solid p-3">Years of Experience</th>
-            <th className="border-2 border-solid p-3">Phone Number</th>
-          </tr>
-        </thead>
-        <tbody>
-          {filteredAdvocates.map((advocate: Advocate) => {
-            return (
-              // TODO: use id from db for key
-              <tr className="border-2 border-solid p-3" key={advocate.phoneNumber}>
-                <td className="border-2 border-solid p-3">{advocate.firstName}</td>
-                <td className="border-2 border-solid p-3">{advocate.lastName}</td>
-                <td className="border-2 border-solid p-3">{advocate.city}</td>
-                <td className="border-2 border-solid p-3">{advocate.degree}</td>
-                <td className="border-2 border-solid p-3">
-                  <ul className="list-inside list-disc">
-                    {advocate.specialties.map((s) => (
-                      <li key={s}>{s}</li>
-                    ))}
-                  </ul>
-                </td>
-                <td className="border-2 border-solid p-3">{advocate.yearsOfExperience}</td>
-                <td className="border-2 border-solid p-3">{advocate.phoneNumber}</td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
+      <h1 className="text-xl mb-10">Solace Advocates</h1>
+      <Search setSearchTerm={setSearchTerm} />
+      {advocatesData.status === 'loading' ? "Loading advocates..." : null}
+      {advocatesData.status === 'error' ? advocatesData.error.message : null}
+      {advocatesData.status === 'success' ?
+        <table>
+          <TableHeader />
+          <TableBody searchTerm={searchTerm} advocates={advocatesData.advocates} />
+        </table> : null
+      }
     </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -28,15 +28,21 @@ export default function Home() {
   const [searchTerm, setSearchTerm] = useState<string>('');
 
   useEffect(() => {
+    let didCancel = false;
     setAdvocatesData({ status: 'loading'})
     console.log("fetching advocates...");
-    fetch("/api/advocates").then((response) => {
-      response.json().then((jsonResponse) => {
-        setAdvocatesData({ status: 'success', advocates: jsonResponse.data})
-      }).catch(error => {
-        setAdvocatesData({ status: 'error', error})
-      })
-    });
+    if (!didCancel) {
+      fetch("/api/advocates").then((response) => {
+        response.json().then((jsonResponse) => {
+          setAdvocatesData({ status: 'success', advocates: jsonResponse.data})
+        }).catch(error => {
+          setAdvocatesData({ status: 'error', error})
+        })
+      });
+    }
+    return () => {
+      didCancel = true;
+    }
   }, []);
 
   return (

--- a/src/app/search.tsx
+++ b/src/app/search.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 import { Advocate } from './page';
 
 interface SearchProps {
-  // advocates: Array<Advocate>
-  // setFilteredAdvocates: (advocatesFiltered: Array<Advocate>) => void
   setSearchTerm: (searchTerm: string) => void
 }
 
@@ -12,19 +10,6 @@ const Search = ({setSearchTerm}: SearchProps) => {
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const searchTerm = e.target.value.toLowerCase();
     setSearchTerm(searchTerm);
-    // const advocatesFiltered = advocates.filter((advocate: Advocate) => {
-    //   const specialtiesWithTerm = advocate.specialties.some((specialty) => specialty.toLowerCase().includes(searchTerm));
-    //   return (
-    //     advocate.firstName.toLowerCase().includes(searchTerm) ||
-    //     advocate.lastName.toLowerCase().includes(searchTerm) ||
-    //     advocate.city.toLowerCase().includes(searchTerm) ||
-    //     advocate.degree.toLowerCase().includes(searchTerm) ||
-    //     advocate.specialties.includes(searchTerm) ||
-    //     specialtiesWithTerm
-    //   );
-    // });
-
-    // setFilteredAdvocates(advocatesFiltered);
   };
 
   const onClick = () => {

--- a/src/app/search.tsx
+++ b/src/app/search.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Advocate } from './page';
+
+interface SearchProps {
+  // advocates: Array<Advocate>
+  // setFilteredAdvocates: (advocatesFiltered: Array<Advocate>) => void
+  setSearchTerm: (searchTerm: string) => void
+}
+
+const Search = ({setSearchTerm}: SearchProps) => {
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const searchTerm = e.target.value.toLowerCase();
+    setSearchTerm(searchTerm);
+    // const advocatesFiltered = advocates.filter((advocate: Advocate) => {
+    //   const specialtiesWithTerm = advocate.specialties.some((specialty) => specialty.toLowerCase().includes(searchTerm));
+    //   return (
+    //     advocate.firstName.toLowerCase().includes(searchTerm) ||
+    //     advocate.lastName.toLowerCase().includes(searchTerm) ||
+    //     advocate.city.toLowerCase().includes(searchTerm) ||
+    //     advocate.degree.toLowerCase().includes(searchTerm) ||
+    //     advocate.specialties.includes(searchTerm) ||
+    //     specialtiesWithTerm
+    //   );
+    // });
+
+    // setFilteredAdvocates(advocatesFiltered);
+  };
+
+  const onClick = () => {
+    setSearchTerm('');
+  };
+
+  return (
+    <div className="mb-10">
+      <label htmlFor="search" className="p-2">Search</label>
+      <input className="border-2 border-solid mr-2" onChange={onChange} id="search" name="search" type="text" />
+      <button className="border-2 border-solid p-1" type="button" onClick={onClick}>Reset Search</button>
+    </div>
+  )
+}
+
+export default Search;

--- a/src/app/tableBody.tsx
+++ b/src/app/tableBody.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Advocate } from './page';
+import TableRow from './tableRow';
+
+interface TableBodyProps {
+  searchTerm?: string;
+  advocates: Array<Advocate>
+}
+
+const TableBody = ({searchTerm, advocates}: TableBodyProps) => {
+  const filteredAdvocates = searchTerm ? advocates.filter((advocate: Advocate) => {
+    const specialtiesWithTerm = advocate.specialties.some((specialty) => specialty.toLowerCase().includes(searchTerm));
+    return (
+      advocate.firstName.toLowerCase().includes(searchTerm) ||
+      advocate.lastName.toLowerCase().includes(searchTerm) ||
+      advocate.city.toLowerCase().includes(searchTerm) ||
+      advocate.degree.toLowerCase().includes(searchTerm) ||
+      advocate.specialties.includes(searchTerm) ||
+      specialtiesWithTerm
+    );
+  }) : advocates;
+
+  return (
+    <tbody>
+      {filteredAdvocates.map((advocate: Advocate) => {
+        return (
+          <TableRow advocate={advocate} />
+        );
+      })}
+    </tbody>
+  )
+}
+
+export default TableBody;

--- a/src/app/tableHeader.tsx
+++ b/src/app/tableHeader.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+const TableHeader = () => {
+  return (
+    <thead>
+      <tr className="bg-black text-white border-2 border-solid text-left">
+        <th className="border-2 border-solid p-3">First Name</th>
+        <th className="border-2 border-solid p-3">Last Name</th>
+        <th className="border-2 border-solid p-3">City</th>
+        <th className="border-2 border-solid p-3">Degree</th>
+        <th className="border-2 border-solid p-3">Specialties</th>
+        <th className="border-2 border-solid p-3">Years of Experience</th>
+        <th className="border-2 border-solid p-3">Phone Number</th>
+      </tr>
+    </thead>
+  )
+}
+
+export default TableHeader;

--- a/src/app/tableRow.tsx
+++ b/src/app/tableRow.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Advocate } from './page';
+
+interface TableRowProps {
+  advocate: Advocate
+}
+
+const TableRow = ({ advocate }: TableRowProps) => {
+  return (
+    // TODO: use id from db for key
+    <tr className="border-2 border-solid p-3" key={advocate.phoneNumber}>
+      <td className="border-2 border-solid p-3">{advocate.firstName}</td>
+      <td className="border-2 border-solid p-3">{advocate.lastName}</td>
+      <td className="border-2 border-solid p-3">{advocate.city}</td>
+      <td className="border-2 border-solid p-3">{advocate.degree}</td>
+      <td className="border-2 border-solid p-3">
+        <ul className="list-inside list-disc">
+          {advocate.specialties.map((s) => (
+            <li key={s}>{s}</li>
+          ))}
+        </ul>
+      </td>
+      <td className="border-2 border-solid p-3">{advocate.yearsOfExperience}</td>
+      <td className="border-2 border-solid p-3">{advocate.phoneNumber}</td>
+    </tr>
+  )
+}
+
+export default TableRow;


### PR DESCRIPTION
## Reason for changes

The previous version of the app did not handle loading or error states for the data fetching. All of the frontend code was in 1 component which made it a bit hard to understand the structure of the page or how state was being managed. The latest changes add in loading and error handling, as well as split out components from the Home page and cut down on the usages of useState to simplify the state management. This PR also includes discussion on possible future improvements.

## Summary of changes

* Add a discriminated union in the Home component to handle the loading / error / success states from the data fetching
* Add searchTerm to local state to keep track of what we should be filtering on
* Display simple loading message when loading, error message when error is present
* Split out the following components:
  * Search --> just updates searchTerm on change / reset of search
  * TableHeader 
  * TableBody --> takes in the searchTerm as a prop to filter the advocates based on the term 
  * TableRow
* Filled out the Discussion.md 

## Screenshots

No UI changes from previous version.